### PR TITLE
linux build changes

### DIFF
--- a/examples/makefile
+++ b/examples/makefile
@@ -9,13 +9,13 @@ all: window renderer
 window: 
 	@echo 'Building Window example ...'
 	$(shell mkdir bin)
-	$(CXX) $(CXXFLAGS) $(DEPFLAGS) $(LDFLAGS) $(LIBS) src/window.cpp -o bin/window-example
+	$(CXX) $(CXXFLAGS) $(DEPFLAGS) $(LDFLAGS)  src/window.cpp -o bin/window-example $(LIBS)
 	cp bin/window-example ../dist/
 
 renderer:
 	@echo 'Building Renderer example ...'
 	$(shell mkdir bin)
-	$(CXX) $(CXXFLAGS) $(DEPFLAGS) $(LDFLAGS) $(LIBS) src/renderer.cpp -o bin/renderer-example
+	$(CXX) $(CXXFLAGS) $(DEPFLAGS) $(LDFLAGS)  src/renderer.cpp -o bin/renderer-example $(LIBS)
 	cp bin/renderer-example ../dist/
 
 clean:

--- a/makefile
+++ b/makefile
@@ -29,7 +29,7 @@ $(PCFILE):
 	$(shell mkdir pkgconfig)
 	echo 'prefix=$(PREFIX)' > $(PCFILE)
 	echo 'exec_prefix=$${prefix}' >> $(PCFILE)
-	echo 'libdir=$${exec_prefix}/lib64' >> $(PCFILE)
+	echo 'libdir=$${exec_prefix}/lib' >> $(PCFILE)
 	echo 'includedir=$${prefix}/include' >> $(PCFILE)
 	echo '' >> $(PCFILE)
 	echo 'Name: kit' >> $(PCFILE)
@@ -41,8 +41,8 @@ $(PCFILE):
 	
 install: $(OUT_LIBRARY) $(PCFILE)
 	cp -r $(INCLUDEDIR)/* $(PREFIX)/include
-	cp lib/$(OUT_LIBRARY) $(PREFIX)/lib64/
-	cp $(PCFILE) $(PREFIX)/lib64/pkgconfig/kit.pc
+	cp lib/$(OUT_LIBRARY) $(PREFIX)/lib/
+	cp $(PCFILE) $(PREFIX)/lib/pkgconfig/kit.pc
 	
 clean:
 	$(shell rm -rf ./build)

--- a/tools/importer/makefile
+++ b/tools/importer/makefile
@@ -14,7 +14,7 @@ OBJECTS      := $(addprefix $(BUILDDIR)/,$(SOURCES:%.cpp=%.o))
 
 $(OUT_BINARY): $(OBJECTS)
 	$(shell mkdir bin)
-	$(CXX) $(CXXFLAGS) $(DEPFLAGS) $(LDFLAGS) $(LIBS) $(OBJECTS) -o bin/$(OUT_BINARY)
+	$(CXX) $(CXXFLAGS) $(DEPFLAGS) $(LDFLAGS) $(OBJECTS) -o bin/$(OUT_BINARY) $(LIBS)
 
 $(BUILDDIR)/%.o: %.cpp
 	@echo 'Building ${notdir $@} ...'

--- a/tools/material-designer/makefile
+++ b/tools/material-designer/makefile
@@ -15,7 +15,7 @@ OBJECTS      := $(addprefix $(BUILDDIR)/,$(SOURCES:%.cpp=%.o))
 
 $(OUT_BINARY): $(OBJECTS)
 	$(shell mkdir bin)
-	$(CXX) $(CXXFLAGS) $(DEPFLAGS) $(LDFLAGS) $(LIBS) $(OBJECTS) -o bin/$(OUT_BINARY)
+	$(CXX) $(CXXFLAGS) $(DEPFLAGS) $(LDFLAGS) $(OBJECTS) -o bin/$(OUT_BINARY) $(LIBS)
 
 $(BUILDDIR)/%.o: %.cpp
 	@echo 'Building ${notdir $@} ...'

--- a/tools/world-editor/makefile
+++ b/tools/world-editor/makefile
@@ -14,7 +14,7 @@ OBJECTS      := $(addprefix $(BUILDDIR)/,$(SOURCES:%.cpp=%.o))
 
 $(OUT_BINARY): $(OBJECTS)
 	$(shell mkdir bin)
-	$(CXX) $(CXXFLAGS) $(DEPFLAGS) $(LDFLAGS) $(LIBS) $(OBJECTS) -o bin/$(OUT_BINARY)
+	$(CXX) $(CXXFLAGS) $(DEPFLAGS) $(LDFLAGS) $(OBJECTS) -o bin/$(OUT_BINARY) $(LIBS)
 
 $(BUILDDIR)/%.o: %.cpp
 	@echo 'Building ${notdir $@} ...'


### PR DESCRIPTION
- I moved the lib flag to the end of each makefile to get the applications to compile on my end. 
- ~~GLFW_CONTEXT_CREATION_API flag does not appear to be in my build of glfw~~
- I changed the install path from lib64 to lib. I'm not sure if this is really necessary since I could modify my own environment variables in terms of pkg-config. usr/lib64 is not available under my system path.
